### PR TITLE
PDF file names with hashtag

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -165,10 +165,13 @@ export default class Pdf2Image extends Plugin {
 			const pdfName = file.name.replace('.pdf', ''); // Get the PDF name without the extension
 			let folderPath = normalizePath(`${await this.getAttachmentFolderPath()}/${pdfName}`); // Create the folder path for images
 
+			// Remove hashtag from folder name if present
+			let cleanPdfName = pdfName.replace(/#/g, '');
 			let folderIndex = 0; // Initialize folder index
+			folderPath = normalizePath(`${await this.getAttachmentFolderPath()}/${cleanPdfName}`); // Use cleaned name
 			while (await this.app.vault.adapter.exists(folderPath)) { // Check if the folder already exists
 				folderIndex++; // Increment folder index
-				folderPath = normalizePath(`${await this.getAttachmentFolderPath()}/${pdfName}_${folderIndex}`); // Update folder path with index
+				folderPath = normalizePath(`${await this.getAttachmentFolderPath()}/${cleanPdfName}_${folderIndex}`); // Update folder path with index
 			}
 
 			await this.app.vault.createFolder(folderPath); // Create the folder


### PR DESCRIPTION
This pull request includes a change to improve folder naming in the `Pdf2Image` plugin by ensuring that hashtags are removed from folder names before creating or checking for folder existence.

Folder naming improvement:

* [`main.ts`](diffhunk://#diff-564c860307257bfac9176f554a35aa858c350a59d75c0dcd0a5d63a480805bd0R168-R174): Updated the folder path creation logic to remove hashtags from the PDF name before generating the folder path, ensuring cleaner and more standardized folder names.