### PR TITLE
Feature/custom image folder

### DIFF
--- a/FolderSuggestModal.ts
+++ b/FolderSuggestModal.ts
@@ -1,24 +1,26 @@
-import { App, FuzzySuggestModal, TFolder } from 'obsidian';
+import { App, AbstractInputSuggest, TFolder } from 'obsidian';
 
-// Add this class before PluginSettingPage
-export class FolderSuggestModal extends FuzzySuggestModal<TFolder> {
-	private onChoose: (folder: TFolder) => void;
+export class FolderSuggest extends AbstractInputSuggest<TFolder> {
+    private inputEl: HTMLInputElement;
 
-	constructor(app: App, onChoose: (folder: TFolder) => void) {
-		super(app);
-		this.onChoose = onChoose;
-		this.setPlaceholder('Type to search folders...');
-	}
+    constructor(app: App, inputEl: HTMLInputElement) {
+        super(app, inputEl);
+        this.inputEl = inputEl;
+    }
 
-	getItems(): TFolder[] {
-		return this.app.vault.getAllFolders();
-	}
+    getSuggestions(query: string): TFolder[] {
+        const folders = this.app.vault.getAllFolders();
+        const lower = query.toLowerCase();
+        return folders.filter(f => f.path.toLowerCase().includes(lower));
+    }
 
-	getItemText(folder: TFolder): string {
-		return folder.path;
-	}
+    renderSuggestion(folder: TFolder, el: HTMLElement): void {
+        el.setText(folder.path);
+    }
 
-	onChooseItem(folder: TFolder): void {
-		this.onChoose(folder);
-	}
+    selectSuggestion(folder: TFolder): void {
+        this.inputEl.value = folder.path;
+        this.inputEl.trigger('input'); // fires onChange
+        this.close();
+    }
 }

--- a/FolderSuggestModal.ts
+++ b/FolderSuggestModal.ts
@@ -1,0 +1,24 @@
+import { App, FuzzySuggestModal, TFolder } from 'obsidian';
+
+// Add this class before PluginSettingPage
+export class FolderSuggestModal extends FuzzySuggestModal<TFolder> {
+	private onChoose: (folder: TFolder) => void;
+
+	constructor(app: App, onChoose: (folder: TFolder) => void) {
+		super(app);
+		this.onChoose = onChoose;
+		this.setPlaceholder('Type to search folders...');
+	}
+
+	getItems(): TFolder[] {
+		return this.app.vault.getAllFolders();
+	}
+
+	getItemText(folder: TFolder): string {
+		return folder.path;
+	}
+
+	onChooseItem(folder: TFolder): void {
+		this.onChoose(folder);
+	}
+}

--- a/PdfProcessor.ts
+++ b/PdfProcessor.ts
@@ -27,12 +27,18 @@ export class PdfProcessor {
             const pdfName = file.name.replace('.pdf', ''); // Remove .pdf extension from file name
             let cleanPdfName = pdfName.replace(/#/g, ''); // Clean name to avoid issues with folder names
             let folderIndex = 0; // Initial folder index for uniqueness
-            let folderPath = normalizePath(`${await getAttachmentFolderPath(this.fileManager)}/${cleanPdfName}`); // Initial folder path
+            let folderPath: string;
+            try {
+                folderPath = normalizePath(`${await getAttachmentFolderPath(this.fileManager, this.settings)}/${cleanPdfName}`);
+            } catch (e) {
+                new Notice('No destination folder selected');
+                return; // No destination folder set
+            }
             
             // If folder with same name exists, append index to make it unique
             while (await this.app.vault.adapter.exists(folderPath)) {
                 folderIndex++;
-                folderPath = normalizePath(`${await getAttachmentFolderPath(this.fileManager)}/${cleanPdfName}_${folderIndex}`);
+                folderPath = normalizePath(`${await getAttachmentFolderPath(this.fileManager, this.settings)}/${cleanPdfName}_${folderIndex}`);
             }
             await this.app.vault.createFolder(folderPath); // Create the unique folder
 

--- a/PdfProcessor.ts
+++ b/PdfProcessor.ts
@@ -28,8 +28,11 @@ export class PdfProcessor {
             let cleanPdfName = pdfName.replace(/#/g, ''); // Clean name to avoid issues with folder names
             let folderIndex = 0; // Initial folder index for uniqueness
             let folderPath: string;
+            let baseFolderPath: string;
+            
             try {
-                folderPath = normalizePath(`${await getAttachmentFolderPath(this.fileManager, this.settings)}/${cleanPdfName}`);
+                baseFolderPath = await getAttachmentFolderPath(this.fileManager, this.settings);
+                folderPath = normalizePath(`${baseFolderPath}/${cleanPdfName}`);
             } catch (e) {
                 new Notice('No destination folder selected');
                 return; // No destination folder set
@@ -38,7 +41,7 @@ export class PdfProcessor {
             // If folder with same name exists, append index to make it unique
             while (await this.app.vault.adapter.exists(folderPath)) {
                 folderIndex++;
-                folderPath = normalizePath(`${await getAttachmentFolderPath(this.fileManager, this.settings)}/${cleanPdfName}_${folderIndex}`);
+                folderPath = normalizePath(`${baseFolderPath}/${cleanPdfName}_${folderIndex}`);
             }
             await this.app.vault.createFolder(folderPath); // Create the unique folder
 

--- a/settings.ts
+++ b/settings.ts
@@ -1,5 +1,5 @@
 import { App, PluginSettingTab, Setting, Plugin } from 'obsidian';
-import { FolderSuggestModal } from './FolderSuggestModal';
+import { FolderSuggest, FolderSuggestModal } from './FolderSuggestModal';
 
 import type Pdf2Image from './main';
 
@@ -74,23 +74,17 @@ export class PluginSettingPage extends PluginSettingTab {
 				new Setting(containerEl)
 					.setName('Destination folder')
 					.setDesc('The folder where images will be saved.')
-					.addText(text => text
-						.setPlaceholder('Select a folder...')
-						.setValue(this.plugin.settings.destinationFolder)
-						.onChange(async (value) => {
-							this.plugin.settings.destinationFolder = value;
-							await this.plugin.saveSettings();
-						}))
-					.addButton(button => button
-						.setButtonText('Browse')
-						.setCta()
-						.onClick(() => {
-							new FolderSuggestModal(this.app, async (folder) => {
-								this.plugin.settings.destinationFolder = folder.path;
+					.addText(text => {
+						text
+							.setPlaceholder('Select a folder...')
+							.setValue(this.plugin.settings.destinationFolder)
+							.onChange(async (value) => {
+								this.plugin.settings.destinationFolder = value;
 								await this.plugin.saveSettings();
-								this.display(); // Refresh to show updated value
-							}).open();
-						}));
+							});
+
+						new FolderSuggest(this.app, text.inputEl);
+					});
 			}
 		}
 

--- a/settings.ts
+++ b/settings.ts
@@ -1,5 +1,5 @@
 import { App, PluginSettingTab, Setting, Plugin } from 'obsidian';
-import { FolderSuggest, FolderSuggestModal } from './FolderSuggestModal';
+import { FolderSuggest } from './FolderSuggestModal';
 
 import type Pdf2Image from './main';
 
@@ -63,29 +63,26 @@ export class PluginSettingPage extends PluginSettingTab {
 				.setValue(this.plugin.settings.useDefaultDestinationFolder)
 				.onChange(async (value) => {
 					this.plugin.settings.useDefaultDestinationFolder = value;
-					this.plugin.settings.destinationFolder = '';
 					await this.plugin.saveSettings();
 					this.display(); // Refresh the settings page to show/hide the custom destination folder setting
 				}));
 
 		/// Custom destination folder setting
 		if (!this.plugin.settings.useDefaultDestinationFolder) {
-			if (!this.plugin.settings.useDefaultDestinationFolder) {
-				new Setting(containerEl)
-					.setName('Destination folder')
-					.setDesc('The folder where images will be saved.')
-					.addText(text => {
-						text
-							.setPlaceholder('Select a folder...')
-							.setValue(this.plugin.settings.destinationFolder)
-							.onChange(async (value) => {
-								this.plugin.settings.destinationFolder = value;
-								await this.plugin.saveSettings();
-							});
+			new Setting(containerEl)
+				.setName('Destination folder')
+				.setDesc('The folder where images will be saved.')
+				.addText(text => {
+					text
+						.setPlaceholder('Select a folder...')
+						.setValue(this.plugin.settings.destinationFolder)
+						.onChange(async (value) => {
+							this.plugin.settings.destinationFolder = value;
+							await this.plugin.saveSettings();
+						});
 
-						new FolderSuggest(this.app, text.inputEl);
-					});
-			}
+					new FolderSuggest(this.app, text.inputEl);
+				});
 		}
 
 		new Setting(containerEl).setName("Image Settings").setHeading();

--- a/settings.ts
+++ b/settings.ts
@@ -1,8 +1,11 @@
 import { App, PluginSettingTab, Setting, Plugin } from 'obsidian';
+import { FolderSuggestModal } from './FolderSuggestModal';
 
 import type Pdf2Image from './main';
 
 export interface PluginSettings {
+	useDefaultDestinationFolder: boolean;
+	destinationFolder: string;
 	enableHeaders: boolean;
 	headerSize: string;
 	headerExtractionSensitive: number;
@@ -15,6 +18,8 @@ export interface PluginSettings {
 }
 
 export const DEFAULT_SETTINGS: PluginSettings = {
+	useDefaultDestinationFolder: true,
+	destinationFolder: '',
 	enableHeaders: false,
 	headerSize: "#",
 	headerExtractionSensitive: 1.2,
@@ -46,6 +51,47 @@ export class PluginSettingPage extends PluginSettingTab {
 
 		// Clear existing content to allow re-rendering when settings change
 		containerEl.empty();
+
+		// Image Destination Folder settings
+		new Setting(containerEl).setName("Image Destination Folder").setHeading();
+
+		// Use default destination folder setting
+		new Setting(containerEl)
+			.setName('Use default destination folder')
+			.setDesc('When enabled, images will be saved in the default folder defined in Obsidian. When disabled, images will be saved in a user specified folder.')
+			.addToggle(toggle => toggle
+				.setValue(this.plugin.settings.useDefaultDestinationFolder)
+				.onChange(async (value) => {
+					this.plugin.settings.useDefaultDestinationFolder = value;
+					await this.plugin.saveSettings();
+					this.display(); // Refresh the settings page to show/hide the custom destination folder setting
+				}));
+
+		/// Custom destination folder setting
+		if (!this.plugin.settings.useDefaultDestinationFolder) {
+			if (!this.plugin.settings.useDefaultDestinationFolder) {
+				new Setting(containerEl)
+					.setName('Destination folder')
+					.setDesc('The folder where images will be saved.')
+					.addText(text => text
+						.setPlaceholder('Select a folder...')
+						.setValue(this.plugin.settings.destinationFolder)
+						.onChange(async (value) => {
+							this.plugin.settings.destinationFolder = value;
+							await this.plugin.saveSettings();
+						}))
+					.addButton(button => button
+						.setButtonText('Browse')
+						.setCta()
+						.onClick(() => {
+							new FolderSuggestModal(this.app, async (folder) => {
+								this.plugin.settings.destinationFolder = folder.path;
+								await this.plugin.saveSettings();
+								this.display(); // Refresh to show updated value
+							}).open();
+						}));
+			}
+		}
 
 		new Setting(containerEl).setName("Image Settings").setHeading();
 

--- a/settings.ts
+++ b/settings.ts
@@ -63,6 +63,7 @@ export class PluginSettingPage extends PluginSettingTab {
 				.setValue(this.plugin.settings.useDefaultDestinationFolder)
 				.onChange(async (value) => {
 					this.plugin.settings.useDefaultDestinationFolder = value;
+					this.plugin.settings.destinationFolder = '';
 					await this.plugin.saveSettings();
 					this.display(); // Refresh the settings page to show/hide the custom destination folder setting
 				}));

--- a/utils.ts
+++ b/utils.ts
@@ -1,4 +1,5 @@
-import { Editor, FileManager } from 'obsidian';
+import { Editor, FileManager, Notice } from 'obsidian';
+import { PluginSettings } from './settings';
 
 /**
  * Returns the appropriate image separator based on the user's setting.
@@ -37,9 +38,18 @@ export function insertImageLink(editor: Editor, insertPosition: { line: number; 
  * Get the folder path where the attachments will be saved
  * Note: If the folder path is not set, use the current note's folder
  */
-export async function getAttachmentFolderPath(fileManager: FileManager): Promise<string> {
-    const basePath = fileManager.getAvailablePathForAttachment('');
-    return basePath;
+export async function getAttachmentFolderPath(fileManager: FileManager, settings: PluginSettings) {
+    // Check if custom destination folder is set in settings
+    if (settings.useDefaultDestinationFolder) { 
+        const basePath = fileManager.getAvailablePathForAttachment('');
+        return basePath;
+    } else {
+        if (settings.destinationFolder == '') {
+            throw new Error('No destination folder selected');
+        } else {
+            return settings.destinationFolder;
+        }
+    }
 }
 
 /** 

--- a/utils.ts
+++ b/utils.ts
@@ -1,4 +1,4 @@
-import { Editor, FileManager, Notice } from 'obsidian';
+import { Editor, FileManager } from 'obsidian';
 import { PluginSettings } from './settings';
 
 /**
@@ -36,7 +36,7 @@ export function insertImageLink(editor: Editor, insertPosition: { line: number; 
 
 /**
  * Get the folder path where the attachments will be saved
- * Note: If the folder path is not set, use the current note's folder
+ * Note: If the folder path is not set, it will throw an error, which should be handled by the caller.
  */
 export async function getAttachmentFolderPath(fileManager: FileManager, settings: PluginSettings) {
     // Check if custom destination folder is set in settings
@@ -44,7 +44,7 @@ export async function getAttachmentFolderPath(fileManager: FileManager, settings
         const basePath = fileManager.getAvailablePathForAttachment('');
         return basePath;
     } else {
-        if (settings.destinationFolder == '') {
+        if (settings.destinationFolder === '') {
             throw new Error('No destination folder selected');
         } else {
             return settings.destinationFolder;


### PR DESCRIPTION
Support for configuring a custom destination folder for saving images, with a folder suggestion UI in the settings. 
Users can now choose between using the default Obsidian attachment folder or specifying a custom folder.