### PR TITLE
Replace builtin-modules with Node.js built-in module.builtinModules

### DIFF
--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -1,6 +1,6 @@
 import esbuild from "esbuild";
 import process from "process";
-import builtins from "builtin-modules";
+import { builtinModules } from "module";
 
 const banner =
 `/*
@@ -31,7 +31,7 @@ const context = await esbuild.context({
 		"@lezer/common",
 		"@lezer/highlight",
 		"@lezer/lr",
-		...builtins],
+		...builtinModules],
 	format: "cjs",
 	target: "es2018",
 	logLevel: "info",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
 				"@types/node": "^16.11.6",
 				"@typescript-eslint/eslint-plugin": "5.29.0",
 				"@typescript-eslint/parser": "5.29.0",
-				"builtin-modules": "3.3.0",
 				"esbuild": "^0.25.5",
 				"obsidian": "^1.7.2",
 				"tslib": "2.4.0",
@@ -1157,18 +1156,6 @@
 			},
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/builtin-modules": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
-			"integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
-			"dev": true,
-			"engines": {
-				"node": ">=6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/callsites": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
 		"@types/node": "^16.11.6",
 		"@typescript-eslint/eslint-plugin": "5.29.0",
 		"@typescript-eslint/parser": "5.29.0",
-		"builtin-modules": "3.3.0",
 		"esbuild": "^0.25.5",
 		"obsidian": "^1.7.2",
 		"tslib": "2.4.0",


### PR DESCRIPTION
The third-party `builtin-modules` npm package is unnecessary since
Node.js exposes the same list natively via `import { builtinModules }
from "module"` (available since Node v9.3).

https://claude.ai/code/session_011B2xQfXJWyDNZ1wovs4fWh